### PR TITLE
Remove fade-in transitions from Play All, remove static transition fr…

### DIFF
--- a/chaos.rpy
+++ b/chaos.rpy
@@ -1,8 +1,9 @@
 ##"Chaos" by Logokas
-label chaos:
+label chaos(preserve_transition=True):
 
     scene bg club_day
-    #with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t5
 
     show sayori 1d zorder 2 at i33
@@ -56,4 +57,7 @@ label chaos:
     window hide(None)
     scene black
     pause 3
+    # Remove the glitch intro of the transition as it's a black screen, so you wouldn't be able to see it anyway.
+    if preserve_transition == False:
+        $ transition_glitch_intro = False
     return

--- a/ddcc.rpy
+++ b/ddcc.rpy
@@ -1,8 +1,9 @@
 ## The Explanation
-label ddcc:
+label ddcc(preserve_transition=True):
 
     scene bg club_day
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t5b
     
     show mc 1 zorder 2 at r11

--- a/script-backups.rpy
+++ b/script-backups.rpy
@@ -1,11 +1,12 @@
 ### "Good thing she keeps backups" - By Chronos#1609
 
 
-label backups:
+label backups(preserve_transition=True):
     
     scene bg club_day
     show monika 2i at f21
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t6
     
     m "...So...would that...be where...?"

--- a/script-ddlc-abridged.rpy
+++ b/script-ddlc-abridged.rpy
@@ -1,10 +1,11 @@
 ## "DDLC Abridged" - By Chronos#1609
 
-label ddlc_abridged:
+label ddlc_abridged(preserve_transition=True):
     
     stop music fadeout 2.0
     scene bg residential_day
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t2
     
     mc "I'm both bored and boring."

--- a/script-external-monologue.rpy
+++ b/script-external-monologue.rpy
@@ -1,9 +1,11 @@
-label external_monologue:
+#"External Monologue" by Tormuse
+label external_monologue(preserve_transition=True):
     $ y_name = "Girl 1"
     $ n_name = "Girl 2"
     $ m_name = "Girl 3"
     scene bg club_day
-    with wipeleft
+    if preserve_transition == True:
+        with wipeleft
     play music t3
     show sayori 4x at l21
     s "Everyone! The new member is here~!"

--- a/script-monikas-surprise.rpy
+++ b/script-monikas-surprise.rpy
@@ -1,7 +1,7 @@
 # "Monika's Surprise" by Tormuse
 # All extra art created by LunaticRabbit
 
-label monikas_surprise:
+label monikas_surprise(preserve_transition=True):
     image monika smug = im.Composite((960, 960), (0, 0), "monika/1l.png", (0, 0), "monika/1r.png", (0, 0), "mod_assets/surprise_smug.png")
     image monika smug2 = im.Composite((960, 960), (0, 0), "monika/1l.png", (0, 0), "monika/1r.png", (0, 0), "mod_assets/surprise_smug2.png")
     image monika mischief = im.Composite((960, 960), (0, 0), "monika/1l.png", (0, 0), "monika/1r.png", (0, 0), "mod_assets/surprise_mischief.png")
@@ -149,5 +149,9 @@ label monikas_surprise:
     hide screen tear
     hide sayori
     scene black
-#    pause 1
+    #Disable the transition's glitch intro because we just had one here.
+    if preserve_transition == False:
+        $ transition_glitch_intro = False
+    window hide
+    $ pause(1.5)
     return

--- a/script-stalker.rpy
+++ b/script-stalker.rpy
@@ -1,12 +1,13 @@
 
 
-label stalker:
+label stalker(preserve_transition=True):
     stop music fadeout 2.0
 
     #Thanks for guiding me so far with the programming Karl... it's # to re-write, huh?
     $ persistent.playthrough = 0
     scene bg stalker_bg
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
 
     #'Hold on, let me just put this in.'
     if player == m_name:

--- a/script-stop.rpy
+++ b/script-stop.rpy
@@ -5,11 +5,12 @@
 ##If that's done, then the extra images made of her could probably be removed, excluding the "closed eyes angry" one.
 ##Also of note: credit both Yagamirai and LunaticRabbit for the sprite assets Monika uses.
 
-label stop:
+label stop(preserve_transition=True):
     
     scene bg club_day
     show monika 1c at t11
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t6
     
     mc "So...what's it like trying to run a literature club?  Are there any challenges that are specific to it?"
@@ -184,5 +185,8 @@ label stop:
     play sound "sfx/crack.ogg"
     pause 3.0
 
+    # Remove the glitch intro of the transition as it's a black screen, so you wouldn't be able to see it anyway.
+    if preserve_transition == False:
+        $ transition_glitch_intro = False
     
     return

--- a/script-transition.rpy
+++ b/script-transition.rpy
@@ -7,6 +7,7 @@
 # Defining the Transition assets
 define audio.transition1 = "mod_assets/transition1.wav"
 image bg transition_image = "mod_assets/shared_assets/transition_image.png"
+define transition_glitch_intro = True
 
 # Transition Code
 # NOTE: For this transition to work properly both in and out, all played skits
@@ -17,11 +18,12 @@ label skit_transition:
 
     # We insert a screen tear first to ease in
     window hide
-    show screen tear(20, 0.1, 0.1, 0, 40)
-    play sound "sfx/s_kill_glitch1.ogg"
-    $ pause(0.3)
-    stop sound
-    hide screen tear
+    if transition_glitch_intro == True:
+        show screen tear(20, 0.1, 0.1, 0, 40)
+        play sound "sfx/s_kill_glitch1.ogg"
+        $ pause(0.3)
+        stop sound
+        hide screen tear
     $ quick_menu = False
     stop music
     show bg transition_image zorder 4
@@ -32,6 +34,7 @@ label skit_transition:
     $ y_name = "Yuri"
     $ n_name = "Natsuki"
     $ m_name = "Monika"
+    $ transition_glitch_intro = True
     
     # Finally a screen tear to ease out
     $ pause (3)

--- a/script-under-new-management.rpy
+++ b/script-under-new-management.rpy
@@ -1,9 +1,10 @@
 ##"Under New Management" by Chronos#1609
-label under_new_management:
+label under_new_management(preserve_transition=True):
     
     scene bg club_day
     show sayori 1b at t11
-    with dissolve_scene_full
+    if preserve_transition == True:
+        with dissolve_scene_full
     play music t5
     
     

--- a/script.rpy
+++ b/script.rpy
@@ -5,21 +5,22 @@ label start:
     stop music fadeout 1.5
     call ddcc from _call_ddcc
     call skit_transition from _call_skit_transition
-    call chaos from _call_chaos
+    call chaos(False) from _call_chaos
     call skit_transition from _call_skit_transition1
-    call stalker from _call_stalker
+    call stalker(False) from _call_stalker
     call skit_transition from _call_skit_transition2
-    call ddlc_abridged from _call_abridged
+    call ddlc_abridged(False) from _call_abridged
     call skit_transition from _call_skit_transition3
-    call backups from _call_backups
+    call backups(False) from _call_backups
     call skit_transition from _call_skit_transition4
-    call under_new_management from _call_management
+    call under_new_management(False) from _call_management
     call skit_transition from _call_skit_transition5
-    call stop from _call_stop
+    call stop(False) from _call_stop
     call skit_transition from _call_skit_transition6
-    call monikas_surprise from _call_monikas_surprise
+    call monikas_surprise(False) from _call_monikas_surprise
     call skit_transition from _call_skit_transition7
-    call external_monologue from _call_external_monologue
+    call external_monologue(False) from _call_external_monologue
+    call skit_transition from _call_skit_transition8
     #TODO: call credits from _call_credits
     return
 


### PR DESCRIPTION
…om skits that fade out

- All skits have a preserve_transition parameter
    - When true, it will fade in as normal.
    - When false, it won't fade in as it expects the glitch transition.
- Skit transition has a transition_glitch_intro parameter
    - When true, the transition will start with a glitch effect
    - When false, it won't.
    - Skits that end on a black screen set the value to false so they won't have an invisible glitch
    - Value is only set to false when preserve_trasition is false, so that it doesn't affect single-play skits.