### PR TITLE
travis: sync to 0.0.5 version

### DIFF
--- a/travis/inject_version.sh
+++ b/travis/inject_version.sh
@@ -4,7 +4,7 @@
 # No need to change anything below the replacer variable.
 # Just change the value of replacer, the script will do everything for you
  
-replacer="0.0.3"
+replacer="0.0.5"
 
 if [ ! -z $TRAVIS_TAG ]; then
   echo " ---> Tag exists, using tag."


### PR DESCRIPTION
Please be reminded not to change the version variable in `options.rpy`. Travis will do it for you via Releases.