### PR TITLE
GUI Fix, Steam Check and DevMode Feat and Bug Fix Part II

### DIFF
--- a/screens.rpy
+++ b/screens.rpy
@@ -514,22 +514,38 @@ screen main_menu():
 
     style_prefix "main_menu"
 
-#Just add Monika art now!
-    
-    #   if persistent.ghost_menu:
-    #      add "white"
-    #     add "menu_art_y_ghost"
-    #    add "menu_art_n_ghost"
-    #    else:
-    add "menu_bg"
-        #add "menu_art_y"
-        #add "menu_art_n"
+    if persistent.ghost_menu:
+         add "white"
+         add "menu_art_y_ghost"
+         add "menu_art_n_ghost"
+    else:
+        add "menu_bg"
+        add "menu_art_y"
+        add "menu_art_n"
     frame:
         pass
 
 ## The use statement includes another screen inside this one. The actual
 ## contents of the main menu are in the navigation screen.
     use navigation
+
+    if not persistent.ghost_menu:
+        add "menu_particles"
+        add "menu_particles"
+        add "menu_particles"
+        add "menu_logo"
+    if persistent.ghost_menu:
+        add "menu_art_s_ghost"
+        add "menu_art_m_ghost"
+    else:
+        if persistent.playthrough == 1 or persistent.playthrough == 2:
+            add "menu_art_s_glitch"
+        else:
+            add "menu_art_s"
+    add "menu_particles"
+    if persistent.playthrough != 4:
+        add "menu_art_m"
+        add "menu_fade"
 
     if gui.show_name:
 
@@ -539,24 +555,6 @@ screen main_menu():
 
             text "[config.version]":
                 style "main_menu_version"
-
-#    if not persistent.ghost_menu:
-    add "menu_particles"
-    add "menu_particles"
-    add "menu_particles"
-    add "menu_logo"
-#    if persistent.ghost_menu:
-#        add "menu_art_s_ghost"
-#        add "menu_art_m_ghost"
-#    else:
-#        if persistent.playthrough == 1 or persistent.playthrough == 2:
-#            add "menu_art_s_glitch"
-#        else:
-#            add "menu_art_s"
-    add "menu_particles"
-#        if persistent.playthrough != 4:
-    add "menu_art_m"
-    add "menu_fade"
 
     key "K_ESCAPE" action Quit(confirm=False)
 

--- a/splash.rpy
+++ b/splash.rpy
@@ -206,7 +206,13 @@ image tos2 = "bg/warning2.png"
 
 
 label splashscreen:
-
+    ## devmode check
+    default devmode = ['Devmode']
+    python:
+        for x in devmode:
+            if player in devmode:
+                config.developer = True
+                renpy.notify('Developer Mode Enabled')
     #If this is the first time the game has been run, show a disclaimer
     default persistent.first_run = False
     if not persistent.first_run:


### PR DESCRIPTION
Resubmit of PR #60 does the following

- Re-add Sayori, Natsuki, and Yuri to the GUI.
- Move the DDCC text in front of Monika.
- Re-add Steam Check for any skits wanting to see if the game is installed in `steamapps`.
- Dev Mode Checker at startup for a list of Developers in splash.rpy. The name must be `Devmode` to work.

Do note you must set your name at the start to `Devmode`, and restart DDLC to enter the hidden Dev Mode Play button.